### PR TITLE
Add implementation for r5

### DIFF
--- a/doc/configuration/config.xml
+++ b/doc/configuration/config.xml
@@ -1,0 +1,9 @@
+<config>
+    <V11>
+        <GisIdRequiredStatuses>
+            <Status>BESTAAND</Status>
+            <Status>REVISIE</Status>
+            <Status>VERWIJDERD</Status>
+        </GisIdRequiredStatuses>
+    </V11>
+</config>

--- a/source_xmls/v11/failing_validations.xml
+++ b/source_xmls/v11/failing_validations.xml
@@ -93,6 +93,34 @@
             </gml:Polygon>
         </Geometry>
     </MSstation>
+    <MSstation>
+        <Handle>5638</Handle>
+        <Naam>MS-12345 Teststation</Naam>
+        <Nummer>12345</Nummer>
+        <DatumAanleg>2023-10-10</DatumAanleg>
+        <Status>NIEUW</Status>
+        <Bedrijfstoestand>IN BEDRIJF</Bedrijfstoestand>
+        <Functie>NETSTATION</Functie>
+        <Straatnaam>Straatnaam</Straatnaam>
+        <Huisnummer>100</Huisnummer>
+        <HuisnummerToevoeging>tv</HuisnummerToevoeging>
+        <Postcode>1234 AB</Postcode>
+        <Plaatsnaam>Plaatsnaam</Plaatsnaam>
+        <Eigenaar>Netbeheerder</Eigenaar>
+        <Beheerder>Netbeheerder</Beheerder>
+        <AssetId>{6D43A69E-C176-401A-8517-E2605079A344}</AssetId>
+        <Geometry>
+            <gml:Polygon
+                srsDimension="2"
+                srsName="EPSG:28992">
+                <gml:exterior>
+                    <gml:LinearRing>
+                        <gml:posList>162051.3975000009 498521.1004999988 162042.91010000184 498514.01579999924 162035.89719999954 498522.2153999992 162044.52840000018 498529.37209999934 262051.3975000009 498521.1004999988</gml:posList>
+                    </gml:LinearRing>
+                </gml:exterior>
+            </gml:Polygon>
+        </Geometry>
+    </MSstation>
     <ABeschermingsvlak>
         <Handle>44AE</Handle>
         <SoortBescherming>"AFDEKPLAAT"</SoortBescherming>

--- a/source_xmls/v11/passing_validations.xml
+++ b/source_xmls/v11/passing_validations.xml
@@ -80,6 +80,8 @@
         <Postcode>1234 AB</Postcode>
         <Plaatsnaam>Plaatsnaam</Plaatsnaam>
         <Eigenaar>Netbeheerder</Eigenaar>
+        <GisId>83412</GisId>
+        <AssetId>{38518CAF-0F42-448D-8CD6-1E655152A0AD}</AssetId>
         <Beheerder>Netbeheerder</Beheerder>
         <AssetId>{6D43A69E-C176-401A-8517-E2605079A344}</AssetId>
         <Geometry>

--- a/validation_schemas/nlcs_plus_plus_schema.sch
+++ b/validation_schemas/nlcs_plus_plus_schema.sch
@@ -29,6 +29,10 @@
         <active pattern="r4-lines-meet-demand"/>
         <active pattern="r4-areas-meet-demand"/>
     </phase>
+
+    <phase id="v11_r5">
+        <active pattern="r5-gisid-assetid-check"/>
+    </phase>
     
     <xsl:include href="xsl_functions/global_functions/config_functions.xsl"/>
     <xsl:include href="xsl_functions/helper_functions/helper_functions.xsl"/>
@@ -48,4 +52,5 @@
     <include href="patterns/aprojectreferentie/v11/complex_all_geometries_in_project_area.sch"/>
     <include href="patterns/general_line/v11/r4-lines-meet-demands.sch"/>
     <include href="patterns/general_area/v11/r4-areas-meet-demands.sch"/>
+    <include href="patterns/general_objects/v11/r5-gisid-assetid-check.sch"/>
 </schema>

--- a/validation_schemas/patterns/general_objects/v11/r5-gisid-assetid-check.sch
+++ b/validation_schemas/patterns/general_objects/v11/r5-gisid-assetid-check.sch
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pattern xmlns ="http://purl.oclc.org/dsdl/schematron" id="r5-gisid-assetid-check">
+    <rule context="//nlcs:MSstation | //nlcs:MSkabel | //nlcs:MSmof | //nlcs:Amantelbuis">
+        <let name="handle" 
+            value="nlcs:Handle"/>
+        
+        <let name="statuses"
+            value="keronic:get-statuses-where-gisid-required()"/>
+        
+        <assert id="gisId-assetId-not-unset-if-new-revision-existing"
+            test="not(some $status in ($statuses) satisfies($status = nlcs:Status)) or (nlcs:GisId and nlcs:AssetId)">
+            Het gis id en assset id mogen niet leeg zijn als de status Revisie, Bestaand of Verwijderd is! Bij het volgende object is het leeg:
+            
+            <value-of select="$handle"/>
+        </assert>
+        
+        <assert id="gisId-assetId-are-unset-if-new"
+            test="some $status in ($statuses) satisfies($status = nlcs:Status) or (not(nlcs:GisId) and not(nlcs:AssetId))">
+            Het gis id en assset id MOETEN leeg zijn als de status NIET Revisie, Bestaand of Verwijderd is! Bij het volgende object is het leeg:
+            
+            <value-of select="$statuses"/>
+        </assert>
+    </rule>
+</pattern>

--- a/validation_schemas/xsl_functions/global_functions/config_functions.xsl
+++ b/validation_schemas/xsl_functions/global_functions/config_functions.xsl
@@ -5,7 +5,7 @@
             xmlns:map="http://www.w3.org/2005/xpath-functions/map"
             version="3.0">
 
-  <variable name="config_file" select= "document('../../../configuration/config.xml')"/>
+  <variable name="config_file" select= "document('../../../doc/configuration/config.xml')"/>
   <variable name="language" select= "'nl'"/>
   <variable name="translation_file" select= "document('../../../localization/messages.xml')"/>
 
@@ -117,6 +117,10 @@
       </call-template>
     </variable>
     <value-of select="$result"/>
+  </function>
+  
+  <function name="keronic:get-statuses-where-gisid-required" as="xs:string*">
+    <sequence select="$config_file/config/V11/GisIdRequiredStatuses/Status"/>
   </function>
 
   <!-- recursively replaces placeholder strings with values from a keyed map -->


### PR DESCRIPTION
### Rule definition
Ieder NLCS Object met de status B, R en V moet een GisId en AssetId hebben, dit zijn namelijk objecten die als oorsprong de assetregistratie hebben. NLCS objecten met de status N en T mogen juist geen GisId en AssetId hebben omdat deze objecten ontstaan in het ontwerp of de revisie.


